### PR TITLE
Fix resolveDependencies progress bar

### DIFF
--- a/lib/fetch-packages.js
+++ b/lib/fetch-packages.js
@@ -142,6 +142,7 @@ async function resolveDependencies(manifest, options) {
         .reduce(async (packages, currManifest) => {
             packages.push({ name: currManifest.name, version: currManifest.version, isLatest: currManifest.isLatest });
             const dependenciesChilds = await resolveDependencies(currManifest, Object.assign(options, { depth: options.depth + 1 }));
+            options.depth -= 1;
 
             // Add the current percent to progress bar (calculate only in packages at the top of the tree)
             if (options.depth === 0) {


### PR DESCRIPTION
Decrement options.depth when coming out of a recursive call

Tested locally. Fixes #25 