### PR TITLE
feat: add no recursive flags for additional dependencies

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -39,6 +39,9 @@ commander
     .option('-d, --dest <dest>', 'Packages destination folder')
     .option('--no-tar', 'Whether to create tar file from all packages')
     .option('--no-cache', 'Whether to save download packages in cache')
+    .option('--no-dev-recursive', 'Whether to recursively resolve dev dependencies')
+    .option('--no-peer-recursive', 'Whether to recursively resolve peer dependencies')
+    .option('--no-optional-recursive', 'Whether to recursively resolve optional dependencies')
     .option('--dev', 'Whether to resolved dev dependencies')
     .option('--peer', 'Whether to resolved peer dependencies')
     .option('--optional', 'Whether to resolved optional dependencies')
@@ -133,6 +136,9 @@ commander
                 dev: command.dev,
                 peer: command.peer,
                 optional: command.optional,
+                devRecursive: command.devRecursive,
+                peerRecursive: command.peerRecursive,
+                optionalRecursive: command.optionalRecursive,
                 registry: command.registry,
                 logger,
             });

--- a/lib/fetch-packages.js
+++ b/lib/fetch-packages.js
@@ -128,6 +128,16 @@ async function resolveDependencies(manifest, options) {
     options.depth = options.depth || 0;
     options.progress = options.progress || 0;
 
+    if (!options.devRecursive) {
+        options.dev = false;
+    }
+    if (!options.peerRecursive) {
+        options.peer = false;
+    }
+    if (!options.optionalRecursive) {
+        options.optional = false;
+    }
+
     // Resolve dependencies childs recursively
     const result = await Bluebird.filter(dependencies, ({ name, version }) => !resolvedPackages.get(name, version))
         .map(({ name, version }) => getPackageManifest(name, version, options).catch(handlerError))


### PR DESCRIPTION
feature: add `--no-dev-recursive`, `--no-peer-recursive`, and `--no-optional-recursive` flags

these flags will only get the provided package.json's additional dependencies

Closes #27 without a breaking change to the cli and likely solves the confusion in #14